### PR TITLE
Chrome is resetting the scroll on hide, so this resets it on show.

### DIFF
--- a/webpages/javascript/AdminParticipants.js
+++ b/webpages/javascript/AdminParticipants.js
@@ -172,6 +172,7 @@ function loadNewParticipant() {
 function showSearchResults() {
 	resultsHidden = false;
 	$("#searchResultsDIV").show("fast");
+	$("#searchResultsDIV").css("overflow-y", "auto");
 	$("#toggleSearchResultsBUTN").prop("disabled", false);
 	$("#toggleText").html("Hide");
 }


### PR DESCRIPTION
One line fix for display hide -> show in adminparticipants search.  This is due to chrome.

We may find it elsewhere as well.