### PR TITLE
Basic theming support

### DIFF
--- a/webpages/CommonHeader.php
+++ b/webpages/CommonHeader.php
@@ -11,6 +11,12 @@ function commonHeader($headerVersion, $isLoggedIn, $noUserRequired, $loginPageSt
     $paramArray["login_page_status"] = $loginPageStatus;
     $paramArray["CON_NAME"] = CON_NAME;
     $paramArray["badgename"] = isset($_SESSION['badgename']) ? $_SESSION['badgename'] : '';
+    if (defined('CON_HEADER_IMG') && CON_HEADER_IMG !== "") {
+        $paramArray["headerimg"] = CON_HEADER_IMG;
+    }
+    if (defined('CON_HEADER_IMG_ALT') && CON_HEADER_IMG_ALT !== "") {
+        $paramArray["headerimgalt"] = CON_HEADER_IMG_ALT;
+    }
     $paramArray["USER_ID_PROMPT"] = USER_ID_PROMPT;
     $paramArray["header_error_message"] = $headerErrorMessage;
     $paramArray["no_user_required"] = $noUserRequired;

--- a/webpages/HtmlHeader.php
+++ b/webpages/HtmlHeader.php
@@ -23,6 +23,13 @@ function html_header($title, $bootstrap4 = false, $isDataTables = false, $report
     <link rel="stylesheet" href="css/zambia_common.css" type="text/css" media="screen" />
 <?php if ($bootstrap4) { ?>
     <link rel="stylesheet" href="css/zambia_bs4.css" type="text/css" media="screen" />
+<?php
+    if (defined('CON_THEME') && CON_THEME !== "") {
+?>
+    <link rel="stylesheet" href="<?php echo CON_THEME ?>" type="text/css" media="screen" />
+<?php
+    }
+?>
 <?php } else { ?>
     <link rel="stylesheet" href="css/zambia.css" type="text/css" media="screen" />
 <?php } ?>

--- a/webpages/db_name_sample.php
+++ b/webpages/db_name_sample.php
@@ -72,4 +72,10 @@ define("REG_PART_PREFIX", "");
 define("CON_THEME", "");
 // if con-specific theming should be applied, you can reference a theme css here.
 // for example: define("CON_THEME", "themes/reallybigcon/main.css");
+define("CON_HEADER_IMG", "");
+// to improve the con branding, you can define a con-specific header image that will take the place of the 
+// Zambia illustrated "Z" image, like so: define("CON_HEADER_IMG", "themes/reallybigcon/header.jpg");
+define("CON_HEADER_IMG_ALT", "");
+// to improve the con branding, you can specify the alt-text of the header image. For example:
+// define("CON_HEADER_IMG_ALT", "Really Big Con Logo);
 ?>

--- a/webpages/db_name_sample.php
+++ b/webpages/db_name_sample.php
@@ -69,4 +69,7 @@ define("USE_REG_SYSTEM", FALSE);
 // False -> Zambia users created and edited by staff users in Zambia
 define("REG_PART_PREFIX", "");
 // only needed for USE_REG_SYSTEM = FALSE; prefix portion of userid/badgeid before counter; can be empty string for no prefix
+define("CON_THEME", "");
+// if con-specific theming should be applied, you can reference a theme css here.
+// for example: define("CON_THEME", "themes/reallybigcon/main.css");
 ?>

--- a/webpages/xsl/GlobalHeader.xsl
+++ b/webpages/xsl/GlobalHeader.xsl
@@ -6,6 +6,8 @@
     <xsl:param name="login_page_status" select="'Normal'" /><!-- "Login", "Logout", "Normal", "Consent", "No_Permission", "Password_Reset" -->
     <xsl:param name="no_user_required" select="false()" /><!-- TRUE/FALSE -->
     <xsl:param name="CON_NAME" select="''" />
+    <xsl:param name="headerimg" select="'images/Z_illuminated.jpg'" />
+    <xsl:param name="headerimgalt" select="'Zambia &quot;Z&quot; logo'" />
     <xsl:param name="badgename" select="''" />
     <xsl:param name="USER_ID_PROMPT" select="'Badge ID'" />
     <xsl:param name="header_error_message" select="''" />
@@ -23,7 +25,10 @@
                         </xsl:when>
                     </xsl:choose>
                     <div class="header-contents">
-                        <img src="images/Z_illuminated.jpg" alt="Zambia &quot;Z&quot; logo" class="wide-only" />
+                        <img class="d-none d-lg-block" >
+                            <xsl:attribute name="src"><xsl:value-of select="$headerimg" /></xsl:attribute>
+                            <xsl:attribute name="alt"><xsl:value-of select="$headerimgalt" /></xsl:attribute>
+	                    </img>
                         <h1 class="wide-medium-only">
                             <xsl:text>Zambia</xsl:text>
                             <span class="wide-only">

--- a/webpages/xsl/GlobalHeader_BS4.xsl
+++ b/webpages/xsl/GlobalHeader_BS4.xsl
@@ -7,6 +7,8 @@
     <xsl:param name="login_page_status" select="'Normal'" /><!-- "Login", "Logout", "Normal", "No_Permission", "Password_Reset" -->
     <xsl:param name="no_user_required" select="false()" /><!-- TRUE/FALSE -->
     <xsl:param name="CON_NAME" select="''" />
+    <xsl:param name="headerimg" select="'images/Z_illuminated.jpg'" />
+    <xsl:param name="headerimgalt" select="'Zambia &quot;Z&quot; logo'" />
     <xsl:param name="badgename" select="''" />
     <xsl:param name="USER_ID_PROMPT" select="'Badge ID'" />
     <xsl:param name="header_error_message" select="''" />
@@ -24,7 +26,10 @@
                         </xsl:when>
                     </xsl:choose>
                     <div class="header-contents">
-                        <img src="images/Z_illuminated.jpg" alt="Zambia &quot;Z&quot; logo" class="d-none d-lg-block" />
+			    <img class="d-none d-lg-block" >
+				    <xsl:attribute name="src"><xsl:value-of select="$headerimg" /></xsl:attribute>
+				    <xsl:attribute name="alt"><xsl:value-of select="$headerimgalt" /></xsl:attribute>
+			    </img>
                         <h1 class="d-none d-md-block">
                             <xsl:text>Zambia</xsl:text>
                             <span class="d-none d-lg-inline">


### PR DESCRIPTION
Per a conversation in Slack, this pull request adds three additional items to the db_name_sample.php to allow an installation to specify:

- a con-specific CSS file that will be added to the list of stylesheets (because BS4 styles differ from BS2 styles, at the moment, this addition only happens in the BS4 pages)
- a con-specific header image
- con-specific alt-text for the header image