### PR TITLE
Support email address as login userid

### DIFF
--- a/webpages/SubmitWelcome.php
+++ b/webpages/SubmitWelcome.php
@@ -6,7 +6,7 @@ $title = "Welcome";
 $interested = getString('interested');
 $password = getString('password');
 $cpassword = getString('cpassword');
-if ($password === "" and $cpassword === "") {
+if (($password === "" or $password === null) and ($cpassword === "" or $cpassword === null)) {
     $update_password = false;
 } elseif ($password === $cpassword) {
     $update_password = true;

--- a/webpages/db_name_sample.php
+++ b/webpages/db_name_sample.php
@@ -44,6 +44,7 @@ define("SECOND_DESCRIPTION_CAPTION", "Description en fran&ccedil;ais");
 define("SECOND_BIOGRAPHY_CAPTION", "Biographie en fran&ccedil;ais");
 define("SHOW_BRAINSTORM_LOGIN_HINT", FALSE);
 define("USER_ID_PROMPT", "User ID"); // What to label User ID / Badge ID
+define("EMAIL_LOGIN_SUPPORTED", FALSE); // Can users use their email address as a userid?
 define("RESET_PASSWORD_SELF", TRUE); // User can reset own password.  Requires email and reCAPTCHA integration.
 define("ROOT_URL", "https://zambia.server.com/"); // URL to reach this zambia server. Required to generate and email password reset link. Include trailing /
 define("PASSWORD_RESET_LINK_TIMEOUT", "PT01H"); // How long until password reset link expires See https://www.php.net/manual/en/dateinterval.construct.php for format.

--- a/webpages/doLogin.php
+++ b/webpages/doLogin.php
@@ -7,7 +7,10 @@ if (!isset($_SESSION['badgeid'])) {
     $title = "Submit Password";
     $badgeid = getString('badgeid');
     $password = getString('passwd');
-    $query = "SELECT password, data_retention FROM Participants WHERE badgeid = ?;";
+    $query = "SELECT p.password, p.data_retention, p.badgeid FROM Participants p WHERE p.badgeid = ?;";
+    if (strpos($badgeid, '@') !== false && defined('EMAIL_LOGIN_SUPPORTED') && EMAIL_LOGIN_SUPPORTED === true) {
+        $query = "SELECT p.password, p.data_retention, p.badgeid FROM Participants p, CongoDump c WHERE p.badgeid = c.badgeid and c.email = ?;";
+    }
     $query_param_arr = array($badgeid);
     if (!$result = mysqli_query_with_prepare_and_exit_on_error($query, 's', $query_param_arr)) {
         exit(); // Should have exited already
@@ -19,6 +22,8 @@ if (!isset($_SESSION['badgeid'])) {
     }
     $dbobject = mysqli_fetch_object($result);
     mysqli_free_result($result);
+    $query_param_arr = array($dbobject->badgeid);
+    $badgeid = $dbobject->badgeid;
     $dbpassword = $dbobject->password;
     $_SESSION['data_consent'] = $dbobject->data_retention;
     if (!password_verify($password, $dbpassword)) {


### PR DESCRIPTION
Allow a user to user their email address, rather than their badge id (which they might not remember) to log in to Zambia