### PR TITLE
Add insert into PatchLog for updates 42, 43

### DIFF
--- a/Install/Upgrade_dbase/42_report_engine_schema.sql
+++ b/Install/Upgrade_dbase/42_report_engine_schema.sql
@@ -36,3 +36,4 @@ CREATE TABLE `CategoryHasReport` (
   CONSTRAINT `FK_CategoryHasReport` FOREIGN KEY (`reportcategoryid`) REFERENCES `ReportCategories` (`reportcategoryid`),
   CONSTRAINT `FK_CategoryHasReport2` FOREIGN KEY (`reporttypeid`) REFERENCES `ReportTypes` (`reporttypeid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+INSERT INTO PatchLog (patchname) VALUES ('42_report_engine_schema.sql');

--- a/Install/Upgrade_dbase/43_configure_rooms.sql
+++ b/Install/Upgrade_dbase/43_configure_rooms.sql
@@ -2,3 +2,4 @@ INSERT INTO PermissionAtoms (permatomid, permatomtag, page, notes)
 	VALUES (16, "configure_rooms", "Configure Rooms", "Also triggers \"Configuration\" menu in staff menu bar.");
 INSERT INTO Permissions (permatomid, permroleid, phaseid)
 	VALUES (16, 1, NULL);
+INSERT INTO PatchLog (patchname) VALUES ('43_configure_rooms.sql');


### PR DESCRIPTION
For completeness and consistency, have updates 42_report_engine_schema.sql and 43_configure_rooms.sql insert into PatchLog like the other updates.