### PR TITLE
Fixes to config editor for EmailTo table in Discon3

### DIFF
--- a/webpages/javascript/EditConfigTables.js
+++ b/webpages/javascript/EditConfigTables.js
@@ -133,7 +133,8 @@ function tceEditor(e, cell) {
     cellname = cell.getField();        
     // initialize the starting value from the current value of the cell
     curcell = cell;
-    txtel.value = cell.getValue().replace(/\n/g, "<br/>");
+    cellValue = cell.getValue();
+    txtel.value = (cellValue ? cellValue.replace(/\n/g, "<br/>") : "");
 
     el = document.getElementById("tceedit-div");
     el.style.display = "block";

--- a/webpages/javascript/EditConfigTables.js
+++ b/webpages/javascript/EditConfigTables.js
@@ -168,6 +168,13 @@ function tceEditor(e, cell) {
     document.getElementById("redo").disabled = true;
 };
 
+function tceEditorBlur(e, cell) {
+    txtel = document.getElementById("tceedit-textarea");
+    if (cell != curcell) {
+        savetceEdit(true);
+    }
+}
+
 function deleteicon(cell, formattParams, onRendered) {
     var value = cell.getValue();
     if (value == 0)
@@ -226,12 +233,14 @@ function opentable(tabledata) {
                 editorParams: editor_params,
                 formatter: "lookup",
                 formatterParams: selectlist,
-                minWidth: 200
+                minWidth: 200,
+                cellClick: tceEditorBlur
             });
         } else if (column.DATA_TYPE == 'int')
             columns.push({
                 title: column.COLUMN_NAME, field: column.COLUMN_NAME,
-                editor: "number", minWidth: 50, hozAlign: "right", 
+                editor: "number", minWidth: 50, hozAlign: "right",
+                cellClick: tceEditorBlur
             });
         else if (column.DATA_TYPE == 'text') {
             width = 8 * column.CHARACTER_MAXIMUM_LENGTH;
@@ -248,6 +257,7 @@ function opentable(tabledata) {
             columns.push({
                 title: column.COLUMN_NAME, field: column.COLUMN_NAME, editor: "input", width: width,
                 editorParams: { editorAttributes: { maxlength: column.CHARACTER_MAXIMUM_LENGTH } },
+                cellClick: tceEditorBlur
             });
         }
     });

--- a/webpages/javascript/EditConfigTables.js
+++ b/webpages/javascript/EditConfigTables.js
@@ -62,6 +62,7 @@ var EditConfigTable = function () {
     }
 
     this.initialize = function () {
+        $('.nav-tabs a').on('click.bs.tab', tceEditorBlur);
        $('.nav-tabs a').on('shown.bs.tab', function (event) {
            var x = event.target.id;         // active tab
             tabshown(x);


### PR DESCRIPTION
This contains fixes for the EditConfigTable to fix issue #125
When using the TCEditor to edit the SQL for EmailTo, this change makes changing cells update the grid and hide the TCEditor.
Also, fixes issue that changing tabs while TCEditor shown left editor visible.
Fixes bug that incorrectly handled null value when adding new row to table.
