### PR TITLE
D3 config table adding row

### DIFF
--- a/webpages/SubmitEditConfigTable.php
+++ b/webpages/SubmitEditConfigTable.php
@@ -116,6 +116,7 @@ function update_table($tablename) {
                 foreach($schema as $col) {
                     if ($col['EXTRA'] != 'auto_increment') {
                         $name = $col['COLUMN_NAME'];
+                        // If uploaded data has column property, and it's not an empty string, add to paramarray. Otherwise add a null (null is needed to prevent error inserting non-char fields).
                         $paramarray[] = (property_exists($row, $name) && trim($row->$name) !== '' ? trim($row->$name) : null);
                     }
                 }
@@ -185,10 +186,6 @@ function update_table($tablename) {
     else
         $message = "";
 
-    if (isset($errmessage)) {
-        $message .= "<p>Database error: " . $errmessage . "</p>";
-    }
-    
     // get updated survey now with the id's in it
     fetch_table($tablename, $message);
 }

--- a/webpages/SubmitEditConfigTable.php
+++ b/webpages/SubmitEditConfigTable.php
@@ -116,14 +116,14 @@ function update_table($tablename) {
                 foreach($schema as $col) {
                     if ($col['EXTRA'] != 'auto_increment') {
                         $name = $col['COLUMN_NAME'];
-                        $paramarray[] = $row->$name;
+                        $paramarray[] = (property_exists($row, $name) && trim($row->$name) !== '' ? trim($row->$name) : null);
                     }
                 }
 
                 //error_log("\n\nInsert of '$id' with datatype of '$datatype'");
                 //error_log($sql);
                 //var_error_log($paramarray);
-                $inserted = $inserted + mysql_cmd_with_prepare($sql, $datatype, $paramarray);
+                $inserted += mysql_cmd_with_prepare($sql, $datatype, $paramarray);
             }
         }
     }
@@ -165,7 +165,7 @@ function update_table($tablename) {
             $paramarray[] = $id;
             //error_log("\n\nupdate of '$id' with '$datatype'\n" . $sql);
             //var_error_log($paramarray);
-            $updated = $updated + mysql_cmd_with_prepare($sql, $datatype, $paramarray);
+            $updated += mysql_cmd_with_prepare($sql, $datatype, $paramarray);
         }
     }
 
@@ -185,6 +185,10 @@ function update_table($tablename) {
     else
         $message = "";
 
+    if (isset($errmessage)) {
+        $message .= "<p>Database error: " . $errmessage . "</p>";
+    }
+    
     // get updated survey now with the id's in it
     fetch_table($tablename, $message);
 }

--- a/webpages/javascript/EditConfigTables.js
+++ b/webpages/javascript/EditConfigTables.js
@@ -214,18 +214,19 @@ function opentable(tabledata) {
             columns.push({ title: "Order", field: "display_order", visible: false });
             display_order = true;
         } else if (fetch_json.hasOwnProperty(column.COLUMN_NAME + "_select")) {
-            selectlistname = column.COLUMN_NAME + "_select";
-            editor_type = 'select';
             selectlist = new Array();
-            fetch_json[column.COLUMN_NAME + "_select"].forEach(function (entry) { selectlist[entry.id] = entry.name; });
-            editor_params = { values: selectlist };
+            formatlist = new Array();
+            fetch_json[column.COLUMN_NAME + "_select"].forEach(function (entry) { 
+                selectlist.push({ label: entry.name, value: entry.id });
+                formatlist[entry.id] = entry.name;
+            });
             columns.push({
                 title: column.COLUMN_NAME, field: column.COLUMN_NAME,
                 visible: true,
-                editor: editor_type,
-                editorParams: editor_params,
+                editor: 'select',
+                editorParams: { values: selectlist },
                 formatter: "lookup",
-                formatterParams: selectlist,
+                formatterParams: formatlist,
                 minWidth: 200
             });
         } else if (column.DATA_TYPE == 'int')


### PR DESCRIPTION
Changes to fix issue #134.

For Rooms table, changed insert logic in SubmitEditConfigTable.php to check for empty string in column, and insert NULL instead.

For RoomHasSet, changes using drop-downs were not saving, as label was being inserted when selecting an item. Changed values in editorParams from array of [id: name] keys to [{ label: name, value: id }] objects. The drop-down now correctly inserts the value instead of the label into the grid data.