### PR TITLE
D3 survey filter fix

### DIFF
--- a/webpages/SubmitFilterParticipants.php
+++ b/webpages/SubmitFilterParticipants.php
@@ -172,12 +172,13 @@ if ($ajax_request_action == "" || !isLoggedIn() || !may_I("Staff")) {
     exit();
 }
 
+error_log("\Request action: $ajax_request_action\n\n");
 switch ($ajax_request_action) {
     case "filter":
         filter_participants();
         break;
     default:
-        $message_error = "Internal error.";
+        $message_error = "Internal error: $ajax_request_action.";
         RenderErrorAjax($message_error);
         exit();
 }

--- a/webpages/SubmitFilterParticipants.php
+++ b/webpages/SubmitFilterParticipants.php
@@ -172,13 +172,12 @@ if ($ajax_request_action == "" || !isLoggedIn() || !may_I("Staff")) {
     exit();
 }
 
-error_log("\Request action: $ajax_request_action\n\n");
 switch ($ajax_request_action) {
     case "filter":
         filter_participants();
         break;
     default:
-        $message_error = "Internal error: $ajax_request_action.";
+        $message_error = "Internal error.";
         RenderErrorAjax($message_error);
         exit();
 }

--- a/webpages/surveyFilterBuild.php
+++ b/webpages/surveyFilterBuild.php
@@ -177,7 +177,7 @@ function survey_filter_build_cte($qcte) {
 function survey_filter_build_join($qcte) {
     $join = "";
     foreach ($qcte as $qid => $cte) {
-        $join .= "JOIN S$qid ON (S$qid.participantid = P.badgeid)\n";
+        $join .= "JOIN (\n$cte\n) S$qid ON (S$qid.participantid = P.badgeid)\n";
 
     }
     return $join;


### PR DESCRIPTION
Fixes to bugs in Survey Filters described in #136.

1. On "Assign to Session", when using filter, "500: Internal Error" raised due to not being able to import surveyFilterBuild.php. This was due to the file being named surveyfilterbuild.php. Renamed file to fix.

2. On "Invite to Session", also received 500 error. This time it was due to SQL trying to link to non-existent "S10" table. This was because it was missing a reference to a subquery, and S10 should be an alias rather than a table. Added correct variable reference to fix.