### PR TITLE
Rebuild reports with con specific items

### DIFF
--- a/webpages/BuildReportMenus.php
+++ b/webpages/BuildReportMenus.php
@@ -113,7 +113,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         <form name="confform" method="POST" action="BuildReportMenus.php">
             <div class="card mt-3">
                 <div class="card-header">
-                    <h5>Rebuild Report Menus</h5>
+                    <h2>Rebuild Report Menus</h2>
                 </div>
                 <div class="card-body">
                     <p class="text-danger">This Admin tool will overwrite your current list of reports and generate a new list.</p>

--- a/webpages/BuildReportMenus.php
+++ b/webpages/BuildReportMenus.php
@@ -138,6 +138,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     if (!may_I('ConfigureReports')) {
         $result = array("severity" => "danger", "text" => "You do not have access to perform this function. Perhaps your session timed out?");
         http_response_code(401);
+        header('Content-type: application/json');
         echo "\n\n";
         echo json_encode($result);
     } else {
@@ -146,10 +147,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         try {
             $allReports = build_report_menus($path);
             $reportCount = count($allReports);
+            header('Content-type: application/json');
+            echo "\n\n";
             $result = array("severity" => "success", "text" => "Done. $reportCount report(s) processed.");
             echo json_encode($result);
         } catch (Exception $e) {
             http_response_code(409);
+            header('Content-type: application/json');
             echo "\n\n";
             $result = array("severity" => "danger", "text" => "We've encountered an error.Check the file system permissions on your server?");
             echo json_encode($result);

--- a/webpages/BuildReportMenus.php
+++ b/webpages/BuildReportMenus.php
@@ -3,6 +3,112 @@
 global $title;
 $title = "Build Report Menus";
 require_once('StaffCommonCode.php'); // Checks for staff permission among other things
+
+
+function process_all_files_in_directory($basePath, $subDirectoryName, &$allReports) {
+    $path = $basePath . $subDirectoryName;
+    $dirHandle = opendir($path);
+    if (!$dirHandle) {
+        throw new Exception("Cannot open directory: $path");
+    }
+    try {
+        while (false !== ($reportFileName = readdir($dirHandle))) {
+            if ($reportFileName == "." || $reportFileName == "..") {
+                // do nothing
+            } else if (is_dir("$path/$reportFileName")) {
+                try {
+                    process_all_files_in_directory($basePath, $subDirectoryName . "/" . $reportFileName, $allReports);
+                } catch (Exception $e) {
+                    // ignore errors opening subdirectories? Is this really what we want, here?
+                    // It's closest to the existing behaviour.
+                }
+            } else if (!mb_ereg_match(".*\\.php$", $reportFileName)) {
+                // do nothing
+            } else {
+                include ("$path/$reportFileName");
+                if (isset($report)) {
+                    // preserve only data needed for menu generation
+                    $key = $subDirectoryName == "" ? $reportFileName : ($subDirectoryName . '/' . $reportFileName);
+                    $allReports[$key] = array('name' => $report['name'], 'description' => $report['description'], 'categories' => $report['categories']);
+                    unset($report);
+                } else {
+                    error_log("cannot worh with : $path/$reportFileName");
+                }
+            }
+        }
+    } finally {
+        closedir($dirHandle);
+    }
+}
+
+function build_report_menus($path) {
+    $allReports = array();
+    process_all_files_in_directory($path, "", $allReports);
+    $reportCategories = array();
+    foreach ($allReports as $reportName => $reportData) {
+        if (isset($reportData['categories'])) {
+            foreach ($reportData['categories'] as $category => $sortOrder) {
+                if (!isset($reportCategories[$category])) {
+                    $reportCategories[$category] = array();
+                }
+                $reportCategories[$category][$reportName] = $sortOrder;
+            }
+        }
+    }
+    ksort($reportCategories, SORT_NATURAL);
+    $reportMenuFilHand = fopen('ReportMenuInclude.php', 'wb');
+    $reportMenuBS4FilHand = fopen('ReportMenuBS4Include.php', 'wb');
+    $staffReportsICIFilHand = fopen('staffReportsInCategoryInclude.php', 'wb');
+    if ($reportMenuFilHand === false || $reportMenuBS4FilHand === false || $staffReportsICIFilHand === false) {
+        staff_header($title, true);
+    ?>
+        <div class="row mt-3">
+            <div class="col-12">
+                <div class="alert alert-danger" role="alert">
+                    Build Reports Failed: invalid permissions, check installation of Zambia.
+                </div>
+            </div>
+        </div>
+    <?php
+        staff_footer();
+        return false;
+    }
+    fwrite($staffReportsICIFilHand, "<?php\n");
+    fwrite($staffReportsICIFilHand, "\$reportCategories = array();\n");
+    foreach ($reportCategories as $reportCategory => $reportCategoryArray) {
+        $encodedReportCategory = htmlentities(urlencode($reportCategory));
+        fwrite($reportMenuFilHand, "<li><a href='staffReportsInCategory.php?reportcategory=$encodedReportCategory'>$reportCategory</a></li>\n");
+        fwrite($reportMenuBS4FilHand, "<a class='dropdown-item' href='staffReportsInCategory.php?reportcategory=$encodedReportCategory'>$reportCategory</a>\n");
+        fwrite($staffReportsICIFilHand, "\$reportCategories['$reportCategory'] = array(");
+        asort($reportCategoryArray, SORT_NUMERIC);
+        $notFirst = false;
+        foreach ($reportCategoryArray as $reportName => $sortOrder) {
+            if ($notFirst) {
+                fwrite($staffReportsICIFilHand, ',');
+            }
+            fwrite($staffReportsICIFilHand, "'$reportName'");
+            $notFirst = true;
+        }
+        fwrite($staffReportsICIFilHand, ");\n");
+    }
+    fwrite($staffReportsICIFilHand, "\$reportNames = array();\n");
+    foreach($allReports as $reportName => $reportArray) {
+        fwrite($staffReportsICIFilHand, "\$reportNames['$reportName'] = '{$reportArray['name']}';\n");
+    }
+    fwrite($staffReportsICIFilHand, "\$reportDescriptions = array();\n");
+    foreach($allReports as $reportName => $reportArray) {
+        $description = addslashes($reportArray['description']);
+        fwrite($staffReportsICIFilHand, "\$reportDescriptions['$reportName'] = \"{$description}\";\n");
+    }
+    fclose($reportMenuFilHand);
+    fclose($reportMenuBS4FilHand);
+    fclose($staffReportsICIFilHand);
+
+    return $allReports;
+}
+
+
+
 if (!may_I('ConfigureReports')) {
     $message_error = "You do not currently have permission to view this page.<br>\n";
     StaffRenderErrorPage($title, $message_error, true);
@@ -12,18 +118,24 @@ $areYouSure = getInt("areYouSure");
 if ($areYouSure !== 1) {
     staff_header($title, true);
 ?>
-<div class="row mt-3">
-    <div class="col-12">
-        <div class="alert alert-danger" role="alert">
-            Rebuild all report menus.  Are you sure?
+<div class="container">
+    <form name="confform" method="GET" action="BuildReportMenus.php">
+        <div class="card mt-3">
+            <div class="card-header">
+                <h5>Rebuild Report Menus</h5>
+            </div>
+            <div class="card-body">
+                <p class="text-danger">This Admin tool will overwrite your current list of reports and generate a new list.</p>
+                <p>Please be sure that you know what you're doing before you hit 'Continue'.</p>
+            </div>
+            <div class="card-footer text-right">
+                <input type="hidden" name="areYouSure" value="1" />
+                <a class="btn btn-link text-muted" href="StaffPage.php">Cancel</a>
+                <button type="submit" class="btn btn-danger mr-3">Continue</button>
+            </div>
         </div>
-    </div>
+    </form>
 </div>
-<form class="form-inline" name="confform" method="GET" action="BuildReportMenus.php">
-    <input type="hidden" name="areYouSure" value="1" />
-    <button type="submit" class="btn btn-primary mr-3">Continue</button>
-    <a class="btn btn-secondary" href="StaffPage.php">Cancel</a>
-</form>
     <?php
     staff_footer();
     exit();
@@ -31,96 +143,21 @@ if ($areYouSure !== 1) {
 ?>
 <?php
 $path = './reports';
-$dirHandle = opendir($path);
-if (!$dirHandle) {
-    $message_error = "Directory $path not found.";
-    RenderError($message_error);
-    exit();
-}
-$allReports = array();
-while (false !== ($reportFileName = readdir($dirHandle))) {
-    if ($reportFileName == "." || $reportFileName == ".." ||
-        is_dir("./reports/$reportFileName") ||
-        !mb_ereg_match(".*\\.php$", $reportFileName)
-    ) {
-        continue;
-    }
-    include ("./reports/$reportFileName");
-    if (isset($report)) {
-        // preserve only data needed for menu generation
-        $allReports[$reportFileName] = array('name' => $report['name'], 'description' => $report['description'], 'categories' => $report['categories']);
-        unset($report);
-    }
-}
-$reportCategories = array();
-foreach ($allReports as $reportName => $reportData) {
-    if (isset($reportData['categories'])) {
-        foreach ($reportData['categories'] as $category => $sortOrder) {
-            if (!isset($reportCategories[$category])) {
-                $reportCategories[$category] = array();
-            }
-            $reportCategories[$category][$reportName] = $sortOrder;
-        }
-    }
-}
-ksort($reportCategories, SORT_NATURAL);
-$reportMenuFilHand = fopen('ReportMenuInclude.php', 'wb');
-$reportMenuBS4FilHand = fopen('ReportMenuBS4Include.php', 'wb');
-$staffReportsICIFilHand = fopen('staffReportsInCategoryInclude.php', 'wb');
-if ($reportMenuFilHand === false || $reportMenuBS4FilHand === false || $staffReportsICIFilHand === false) {
+$allReports = build_report_menus($path);
+if ($allReports) {
+    $reportCount = count($allReports);
     staff_header($title, true);
-?>
+    ?>
     <div class="row mt-3">
         <div class="col-12">
-            <div class="alert alert-danger" role="alert">
-                Build Reports Failed: invalid permissions, check installation of Zambia.
+            <div class="alert alert-success" role="alert">
+                Done.<br />
+                <?php echo $reportCount; ?> report(s) processed.
             </div>
         </div>
     </div>
-<?php
+    <?php
     staff_footer();
-    return;
 }
-fwrite($staffReportsICIFilHand, "<?php\n");
-fwrite($staffReportsICIFilHand, "\$reportCategories = array();\n");
-foreach ($reportCategories as $reportCategory => $reportCategoryArray) {
-    $encodedReportCategory = htmlentities(urlencode($reportCategory));
-    fwrite($reportMenuFilHand, "<li><a href='staffReportsInCategory.php?reportcategory=$encodedReportCategory'>$reportCategory</a></li>\n");
-    fwrite($reportMenuBS4FilHand, "<a class='dropdown-item' href='staffReportsInCategory.php?reportcategory=$encodedReportCategory'>$reportCategory</a>\n");
-    fwrite($staffReportsICIFilHand, "\$reportCategories['$reportCategory'] = array(");
-    asort($reportCategoryArray, SORT_NUMERIC);
-    $notFirst = false;
-    foreach ($reportCategoryArray as $reportName => $sortOrder) {
-        if ($notFirst) {
-            fwrite($staffReportsICIFilHand, ',');
-        }
-        fwrite($staffReportsICIFilHand, "'$reportName'");
-        $notFirst = true;
-    }
-    fwrite($staffReportsICIFilHand, ");\n");
-}
-fwrite($staffReportsICIFilHand, "\$reportNames = array();\n");
-foreach($allReports as $reportName => $reportArray) {
-    fwrite($staffReportsICIFilHand, "\$reportNames['$reportName'] = '{$reportArray['name']}';\n");
-}
-fwrite($staffReportsICIFilHand, "\$reportDescriptions = array();\n");
-foreach($allReports as $reportName => $reportArray) {
-    $description = addslashes($reportArray['description']);
-    fwrite($staffReportsICIFilHand, "\$reportDescriptions['$reportName'] = \"{$description}\";\n");
-}
-fclose($reportMenuFilHand);
-fclose($reportMenuBS4FilHand);
-fclose($staffReportsICIFilHand);
-$reportCount = count($allReports);
-staff_header($title, true);
+
 ?>
-<div class="row mt-3">
-    <div class="col-12">
-        <div class="alert alert-success" role="alert">
-            Done.<br />
-            <?php echo $reportCount; ?> report(s) processed.
-        </div>
-    </div>
-</div>
-<?php
-staff_footer();

--- a/webpages/javascript/BuildReportMenus.js
+++ b/webpages/javascript/BuildReportMenus.js
@@ -1,0 +1,33 @@
+
+$(function() {
+    console.log("thing");
+    $('#build-report-btn').click(function() {
+        let url = $('#build-report-btn').closest('form').attr("action");
+        $('.alert').remove();
+        $('#build-report-btn .spinner-border').show();        
+        $.ajax({
+            url: url,
+            type: 'POST',
+            success: function(data) {
+                $('#build-report-btn .spinner-border').hide();
+                showMessage(data);
+            },
+            error: function(response) {
+                $('#build-report-btn .spinner-border').hide();
+                showMessage(response.data);
+            }
+        });
+    });
+
+    function showMessage(data) {
+        try {
+            data = JSON.parse(data);
+        } catch {
+            data = { "severity": "danger", "text": data};
+        }
+        let alert = $('<div class="mt-3 alert"></div>');
+        alert.addClass('alert-' + data.severity);
+        alert.text(data.text);
+        $('.card').before(alert);
+    }
+});

--- a/webpages/javascript/BuildReportMenus.js
+++ b/webpages/javascript/BuildReportMenus.js
@@ -8,7 +8,7 @@ $(function() {
         $.ajax({
             url: url,
             type: 'POST',
-            success: function(data) {
+            success: function(data, response) {
                 $('#build-report-btn .spinner-border').hide();
                 showMessage(data);
             },
@@ -20,10 +20,15 @@ $(function() {
     });
 
     function showMessage(data) {
-        try {
-            data = JSON.parse(data);
-        } catch {
-            data = { "severity": "danger", "text": data};
+        if (typeof user === 'string') {
+            try {
+                data = JSON.parse(data);
+            } catch {
+                if (data.indexOf('<div') == 0) {
+                    data = $(data).text();
+                }
+                data = { "severity": "danger", "text": data};
+            }
         }
         let alert = $('<div class="mt-3 alert"></div>');
         alert.addClass('alert-' + data.severity);


### PR DESCRIPTION
When building the list of reports, traverse into subdirectories (where, for example, con-specific reports could be saved) and include those reports in the menu items and report list pages. This pull request doesn't fully address some of the considerations discussed in #124, but it's a step in that direction.

Also: some look-and-feel adjustments have been made to the report page, plus Ajax-ify-ing of the behaviour.